### PR TITLE
释放连接池将ping方法设置成nil

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -171,6 +171,7 @@ func (c *channelPool) Release() {
 	conns := c.conns
 	c.conns = nil
 	c.factory = nil
+	c.ping = nil
 	closeFun := c.close
 	c.close = nil
 	c.mu.Unlock()


### PR DESCRIPTION
释放连接池后ping方法没有设置成nil，修复了；