### PR TITLE
Fix blocking bug in TestPool_Get and add some unit tests

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -3,15 +3,19 @@ package pool
 import (
 	"errors"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 	//"reflect"
 )
 
 var (
 	//ErrMaxActiveConnReached 连接池超限
 	ErrMaxActiveConnReached = errors.New("MaxActiveConnReached")
+	ErrInvalidCapSetting    = errors.New("invalid capacity settings")
+	ErrInvalidFactoryFunc   = errors.New("invalid factory func settings")
+	ErrInvalidCloseFunc     = errors.New("invalid close func settings")
 )
 
 // Config 连接池相关配置
@@ -57,13 +61,13 @@ type idleConn struct {
 // NewChannelPool 初始化连接
 func NewChannelPool(poolConfig *Config) (Pool, error) {
 	if !(poolConfig.InitialCap <= poolConfig.MaxIdle && poolConfig.MaxCap >= poolConfig.MaxIdle && poolConfig.InitialCap >= 0) {
-		return nil, errors.New("invalid capacity settings")
+		return nil, ErrInvalidCapSetting
 	}
 	if poolConfig.Factory == nil {
-		return nil, errors.New("invalid factory func settings")
+		return nil, ErrInvalidFactoryFunc
 	}
 	if poolConfig.Close == nil {
-		return nil, errors.New("invalid close func settings")
+		return nil, ErrInvalidCloseFunc
 	}
 
 	c := &channelPool{


### PR DESCRIPTION
你好，当我运行单元测试文件`channel_rpc_test.go`的时候，发现在`TestPool_Get`中pool可用连接达到了最大的连接上限`MaximumCap`时，再次调用了`Get`导致了测试的长期阻塞，而非返回`ErrMaxActiveConnReached`错误。于是我进行了一些小修改，并且添加了一些新的单元测试函数，这使得测试覆盖率提升到了85%

Hello, when I run the unit test file `channel_rpc_test.go`, I found that when the available connections of the pool in `TestPool_Get` reached the maximum connection limit `MaximumCap`, calling `Get` again caused the long-term blocking of the test, Instead of returning an `ErrMaxActiveConnReached` error. So I made some small changes and added some new unit test functions, which increased the test coverage to 85%